### PR TITLE
make task 9

### DIFF
--- a/app/controllers/meteors.controller.js
+++ b/app/controllers/meteors.controller.js
@@ -1,13 +1,23 @@
 import express from "express";
 import getFormattedMeteors from "../services/meteors.service.js";
+import { validateDate } from "../utils/utils.js";
 const router = express.Router();
 
 router.get("/meteors", async (req, res, next) => {
-  const startDate = "2024-11-17";
-  const endDate = "2024-11-18";
+  const dates = validateDate(req.query?.date);  
+  const count = req.query?.count;
+  const wereDangerousMeteors = req.query?.wereDangerousMeteors;
+
   try {
-    const formattedMeteors = await getFormattedMeteors(startDate,endDate);
-    res.send(formattedMeteors);
+    const formattedMeteors = await getFormattedMeteors(
+      dates,
+      count,
+      wereDangerousMeteors
+    );
+    
+    res.send(
+      formattedMeteors
+    );
   } catch (error) {
     next(error);
   }

--- a/app/services/meteors.service.js
+++ b/app/services/meteors.service.js
@@ -1,11 +1,11 @@
 import fetchMeteors from "../repositories/meteors.repository.js";
 
 export default async function getFormattedMeteors(
-  dates,
+  [startDate, endDate],
   count,
   wereDangerousMeteors
 ) {
-  const meteors = await fetchMeteors(dates[0], dates[1]);
+  const meteors = await fetchMeteors(startDate, endDate);
   let queryResponse = {};
   let formattedMeteors = Object.keys(meteors).flatMap((date) =>
     meteors[date].map((meteor) => ({

--- a/app/services/meteors.service.js
+++ b/app/services/meteors.service.js
@@ -1,9 +1,13 @@
-import  fetchMeteors  from "../repositories/meteors.repository.js";
+import fetchMeteors from "../repositories/meteors.repository.js";
 
-export default async function getFormattedMeteors(startDate,endDate) {
-  const meteors = await fetchMeteors(startDate,endDate);
-
-  const formattedMeteors = Object.keys(meteors).flatMap((date) =>
+export default async function getFormattedMeteors(
+  dates,
+  count,
+  wereDangerousMeteors
+) {
+  const meteors = await fetchMeteors(dates[0], dates[1]);
+  let queryResponse = {};
+  let formattedMeteors = Object.keys(meteors).flatMap((date) =>
     meteors[date].map((meteor) => ({
       id: meteor.id,
       name: meteor.name,
@@ -16,5 +20,18 @@ export default async function getFormattedMeteors(startDate,endDate) {
         meteor.close_approach_data[0]?.relative_velocity?.kilometers_per_second,
     }))
   );
-  return formattedMeteors
+
+  if (count === "true") {
+    queryResponse.count = formattedMeteors.length;
+  }
+  if (wereDangerousMeteors === "true") {
+    queryResponse.wereDangerousMeteors = formattedMeteors.some(
+      (meteor) => meteor.is_potentially_hazardous_asteroid
+    );
+  }
+
+
+  return count === "true" || wereDangerousMeteors === "true"
+    ? queryResponse
+    : formattedMeteors;
 }

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,0 +1,14 @@
+export const validateDate = (queryDateArr) => {
+  let dateArr = ["2024-11-17", "2024-11-18"];
+  
+  dateArr[0] = queryDateArr?.length === 2 ? queryDateArr[0] : "2024-11-17";
+
+  dateArr[1] =
+    queryDateArr?.length === 2
+      ? queryDateArr[1]
+      : queryDateArr?.length === 1
+      ? queryDateArr
+      : "2024-11-18";
+
+  return dateArr;
+};


### PR DESCRIPTION
Task-9: Add parameters to the query
In this task, we need to extend the capabilities of the existing endpoint /meteors.

We will pass query parameters in the query to control the logic on the server.

 

Query params:

date helps to set the period during which we are interested in information on meteorites
count returns only the number of meteorites that have been seen.
were-dangerous-meteors returns true or false whether they have been seen among meteorites potentially dangerous to Earth.
Each of the parameters is optional, but if present, the data from the NASA API should match the given date. Date range like date=[2024-10-10,2024-10-12] is allowed

 

Acceptance criteria:

Add date, count and were-dangerous-meteors as a parameter to the query
Consider the possibility of passing several, all or none of the parameters
 

Recommended materials:

[date-fns](https://date-fns.org/)

 

Example:

/meteors?date=2024-10-09&count=true&wereDangerousMeteors=true

/meteors?date[]=2024-10-10&date[]=2024-10-12&count=true&wereDangerousMeteors=true